### PR TITLE
Feature: Automatically close application form and CF worker

### DIFF
--- a/app/Components/body/body.tsx
+++ b/app/Components/body/body.tsx
@@ -1,10 +1,64 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import JobList from './joblist/joblist';
 import Form from './form/form';
+import { checkApplicationStatus } from '../send';
 
 export default function Body() {
     const [selectedJob, setSelectedJob] = useState(-1);
+    const [applicationsClosed, setApplicationsClosed] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const checkStatus = async () => {
+            try {
+                const isClosed = await checkApplicationStatus();
+                setApplicationsClosed(isClosed);
+            } catch (error) {
+                console.error('Failed to check application status:', error);
+                setApplicationsClosed(false); // Default to allowing applications
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        checkStatus();
+    }, []);
+
+    if (isLoading) {
+        return (
+            <div className="w-full">
+                <div className="relative mx-auto min-w-sm max-w-4xl mt-5">
+                    <div className="flex flex-col items-center justify-center p-10">
+                        <p className="text-lg">Loading...</p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (applicationsClosed) {
+        return (
+            <div className="w-full">
+                <div className="relative mx-auto min-w-sm max-w-4xl mt-5">
+                    <div className="flex flex-col items-center justify-center p-10">
+                        <h2 className="font-bold text-center text-2xl p-5">
+                            Volunteer Opportunities
+                        </h2>
+                        <div className="bg-gray-100 border border-gray-300 rounded-lg p-8 text-center max-w-md">
+                            <h3 className="text-xl font-semibold text-gray-700 mb-2">
+                                Applications Closed
+                            </h3>
+                            <p className="text-gray-600">
+                                No available volunteer roles at this time. The
+                                application period has ended.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="w-full">

--- a/app/Components/send.ts
+++ b/app/Components/send.ts
@@ -4,6 +4,19 @@ const WORKER_URL = import.meta.env.DEV
     ? 'http://127.0.0.1:8787' // Calls local worker if in dev env (use 'npx run dev') to run a local worker
     : 'https://volunteer-worker.brockcsc.workers.dev';
 
+export const checkApplicationStatus = async (): Promise<boolean> => {
+    try {
+        // Check if applications are closed (after midnight September 22, 2025)
+        const now = new Date();
+        const cutoffDate = new Date('2025-09-22T00:00:00-04:00'); // Midnight EDT (Toronto timezone)
+
+        return now >= cutoffDate;
+    } catch (error) {
+        console.error('Check Application Status Error:', error);
+        return false; // Default to allowing applications if check fails
+    }
+};
+
 export const sendApplication = async (
     formData: formFields,
     roleTitle: string,

--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -113,6 +113,28 @@ export default {
             });
         }
 
+        // Check if applications are closed (after midnight September 22, 2025)
+        const now = new Date();
+        const cutoffDate = new Date('2025-09-22T00:00:00-04:00'); // Midnight EDT (Toronto timezone)
+
+        if (now >= cutoffDate) {
+            return new Response(
+                JSON.stringify({
+                    success: false,
+                    message: 'Application period has ended',
+                    closed: true,
+                }),
+                {
+                    status: 410, // Gone - indicates the resource is no longer available
+                    headers: {
+                        ...SECURITY_HEADERS,
+                        'Content-Type': 'application/json',
+                        ...corsHeaders,
+                    },
+                },
+            );
+        }
+
         // Get client IP
         const clientIP = request.headers.get('CF-Connecting-IP') || '';
 


### PR DESCRIPTION
# Feature: Automatically close application form and CF worker
## Purpose
We need the volunteer role applications to close at 00:00:00 AM on the 22nd September, EST. For this purpose. This PR hard codes this date into the codebase for both the frontend and on the CF worker. The front-end will display that applications are no longer open, and the CF worker will return HTTP 410 if requests are made past the close date.

## Changes
**CF Worker Changes:**
- The Cloudflare worker will now respond with a HTTP 410 with the message "Application period has ended" if it is called after the application close date of 00:00:00 AM on 22nd September, EST.

**Front-end:**
- Adds a client-side TS function called `checkApplicationStatus()` which returns if the application period has ended (i.e. It is past 00:00:00 AM on the 22nd September, EST).
- If the application has closed, implements a new division which displayed that the application has closed. *[Image Attached]*
<img width="842" height="740" align="center" alt="image" src="https://github.com/user-attachments/assets/50e6f5a6-1faf-468c-91f0-4898c1277c73" />

## Future Implications
The close time for the applications has been hard coded to be 00:00:00 AM on September 22nd, EST. In the future it would be nice to not hard code such values and rather have a admin console where this can be managed. This also plays a part into the future implications talked about in #3
